### PR TITLE
fix(goreleaser): publish formula under HomebrewFormula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,7 @@ brews:
       owner: kcl-lang
       name: homebrew-tap
       branch: main
+    directory: HomebrewFormula
     url_template: "https://github.com/kcl-lang/cli/releases/download/{{ .Tag }}/kcl-v{{ .Version }}-{{ .Os }}-{{ .Arch }}.tar.gz"
     homepage: "https://github.com/kcl-lang/kcl"
     description: "KCL Command Line Interface"


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y

Related to https://github.com/kcl-lang/homebrew-tap/issues/10 and https://github.com/kcl-lang/homebrew-tap/pull/9.

#### 2. What is the scope of this PR (e.g. component or file name):

`.goreleaser.yml`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

Restore the Homebrew formula destination that was lost during the GoReleaser v2 configuration migration.

The previous configuration used `folder: HomebrewFormula`. GoReleaser v2 calls this property `directory`. Without it, releases publish `kcl.rb` at the tap repository root, outside the formula directory recognized by Homebrew.

This change keeps the existing formula-based distribution scoped as-is. Migrating the deprecated `brews` publisher to Homebrew casks can be handled separately.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

- `git diff --check` passes.
- GoReleaser v2.17 accepts the configuration. Its existing `brews` deprecation warning is identical before and after this change.
- `go run github.com/goreleaser/goreleaser/v2@v2.17.0 release --snapshot --clean --skip=before` completed successfully and wrote `dist/homebrew/HomebrewFormula/kcl.rb`.
- No root-level Homebrew formula was generated.
