### PR TITLE
Chore: (deps): bump kcl-lang.io/kcl-openapi from 0.10.3 to 0.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.1
 	kcl-lang.io/kcl-go v0.12.4
-	kcl-lang.io/kcl-openapi v0.10.3
+	kcl-lang.io/kcl-openapi v0.11.0
 	kcl-lang.io/kcl-plugin v0.11.0
 	kcl-lang.io/kpm v0.12.8
 )
@@ -28,6 +28,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.12 // indirect
@@ -65,6 +66,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/google/cel-go v0.10.1 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -90,6 +92,7 @@ require (
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20240416193709-1e18ef0a7fdc // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.58.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1354,8 +1354,8 @@ k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 kcl-lang.io/kcl-go v0.12.4 h1:B5ZIN8ZGnM2dS7DNWNlZ02HGrXZM6S67BpnQ9mYRSkA=
 kcl-lang.io/kcl-go v0.12.4/go.mod h1:IN98r5IyIwz0aek0/tp/52sFy7OCLU/v430ifg28fFU=
-kcl-lang.io/kcl-openapi v0.10.3 h1:IZTxcY9OqOEhnpIeya9fH3FdrEmDUIGXwGxdr9+w+zs=
-kcl-lang.io/kcl-openapi v0.10.3/go.mod h1:kGCf0AZygrZyB+xpmMtiC3FYoiV/1rCLXuAq2QtuLf8=
+kcl-lang.io/kcl-openapi v0.11.0 h1:qHGuEzSgiv1hYwtkHI9JGkC7sTfggDlKsXt019pfYm8=
+kcl-lang.io/kcl-openapi v0.11.0/go.mod h1:YhziGw8vsjTq4qrJUu05CDx2nQDna7znLQABkxiKzew=
 kcl-lang.io/kcl-plugin v0.11.0 h1:Get9hvYhQDS180GOqhdhKwxRcZGKUGvPkQkqEOfcwtk=
 kcl-lang.io/kcl-plugin v0.11.0/go.mod h1:0H6hJEYMyPUm0zJQP0bgTuNrqktwgA21EcUvQTiZIb4=
 kcl-lang.io/kpm v0.12.8 h1:NXo6Uh5PoiBF918jo73mwE5HH7AiQ6Lj8CwEhSSg7VQ=


### PR DESCRIPTION
## Summary
- Bumps `kcl-lang.io/kcl-openapi` from `0.10.3` to `0.11.0`.
- Refreshes `go.sum` via `go mod tidy`, picking up the new indirect deps pulled in by the CEL-based x-kubernetes-validations support (antlr4, cel-go, go-strcase, plus bumped Google / OTel / AWS / protobuf / cel.dev transitives).

## Why
0.11.0 is the current upstream release of `kcl-openapi`. Highlights since 0.10.3:
- `feat`: support OpenAPI 3.0/3.1 specs (closes #35) (#162)
- `feat`: translate `x-kubernetes-validations` (CEL) into KCL check rules (fixes #22) (#161)
- `feat`: `--existing-models` flag reuses pre-generated KCL models (fixes #18) (#160)
- `fix(generator)`: emit per-element regex check for array fields with pattern (#157)
- `fix(generator)`: skip comment-only YAML documents in `splitDocuments` (#158)

## API compatibility
`pkg/options/import.go` only touches:
- `generator.GenOpts{ Spec, Target, ValidateSpec, ModelPackage }` + `EnsureDefaults()` + `Generate(*GenOpts)` — all preserved.
- `crdGen.GenOpts{ Spec }` + `GetSpecs(*GenOpts)` — unchanged.

So no source changes are required; this is a pure go.mod / go.sum bump.

## Verification
- `go mod tidy` clean
- `go build -tags rpc ./cmd/kcl/` builds a working `kcl` binary
- `go vet ./...` clean
- Smoke-tested `kcl import -m openapi` against a sample OpenAPI 3.0 spec, generated KCL schemas are correct

## Test plan
- [ ] CI green
- [ ] Smoke-test the resulting `kcl` binary (`kcl import -m openapi ...`, `kcl import -m crd ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)