### PR TITLE
fix(deps): bump github.com/buger/jsonparser to v1.6.1 (fixes #376)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/buger/jsonparser v1.6.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/jsonv v1.1.3 // indirect
 	github.com/chai2010/protorpc v1.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/buger/jsonparser v1.6.1 h1:I0phFv0PlbLHnM7TZAVjZ2MJ2/eWRTDyuO7GLR98IEs=
+github.com/buger/jsonparser v1.6.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=


### PR DESCRIPTION
`go.mod` pinned `github.com/buger/jsonparser v1.1.1` (released 2021-01-08), which is vulnerable to CVE-2026-32285: the `Delete` function does not validate the start/end offsets before slicing the input byte slice, so malformed JSON can trigger a runtime panic (slice bounds out of range) — a HIGH-severity denial-of-service.

`jsonparser` is a transitive indirect dependency here (pulled in via `kcl-go/pkg/tools/gen`), but the project is what pins the old version in `go.mod`, so the bump has to happen in this repo.

Bump to v1.6.1 (released 2026-07-30), the latest stable that includes the v1.1.2 bounds-check fix plus a pile of subsequent correctness and performance work.

Verified locally:

- `go build ./cmd/...` succeeds.
- `go test ./pkg/... ./cmd/kclx/...` still passes.
- The pre-existing panic in `TestModCmdWithSkipTlsVerify` (nil `*DepGraph` deref inside `kpm@v0.12.9`) reproduces on `main` and is unrelated to this bump — happy to file a follow-up for that separately if useful.

Diff: 2 files changed, 3 insertions(+), 3 deletions(-).

Fixes #376