### PR TITLE
feat(lint): support kcl lint ./... to lint all packages

### DIFF
--- a/cmd/kcl/commands/lint.go
+++ b/cmd/kcl/commands/lint.go
@@ -10,13 +10,22 @@ import (
 const (
 	lintDesc = `This command lints the kcl code. 'kcl lint' takes multiple input for arguments.
 
-For example, 'kcl lint path/to/kcl.k' will lint the file named path/to/kcl.k 
+For example, 'kcl lint path/to/kcl.k' will lint the file named path/to/kcl.k
+
+'kcl lint ./...' lints all the kcl packages under the current directory, one
+package per directory, like 'go build ./...'
 `
 	lintExample = `  # Lint a single file and output YAML
   kcl lint path/to/kcl.k
 
   # Lint multiple files
   kcl lint path/to/kcl1.k path/to/kcl2.k
+
+  # Lint all the packages under the current directory
+  kcl lint ./...
+
+  # Lint all the packages under a specific directory
+  kcl lint path/to/pkg/...
 
   # Lint OCI packages
   kcl lint oci://ghcr.io/kcl-lang/helloworld
@@ -34,6 +43,9 @@ func NewLintCmd() *cobra.Command {
 		Long:    lintDesc,
 		Example: lintExample,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if options.HasLintPattern(args) {
+				return o.LintAllPackages(args)
+			}
 			if err := o.Complete(args); err != nil {
 				return err
 			}

--- a/pkg/options/lint.go
+++ b/pkg/options/lint.go
@@ -1,0 +1,118 @@
+// Copyright The KCL Authors. All rights reserved.
+
+package options
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// HasLintPattern reports whether any of the args is a `...` pattern
+// (e.g. `./...` or `pkg/...`) that selects all the KCL packages under
+// a directory, like `go build ./...`.
+func HasLintPattern(args []string) bool {
+	for _, arg := range args {
+		if isLintPattern(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+// isLintPattern reports whether the path is a `...` package pattern.
+func isLintPattern(path string) bool {
+	return filepath.Base(path) == "..."
+}
+
+// LintAllPackages lints every KCL package selected by args. It supports
+// `...` patterns (e.g. `./...` or `pkg/...`): every directory holding KCL
+// files under the pattern root is linted as one package, so symbols of
+// distinct packages never collide. Plain files and directories passed
+// alongside a pattern join the package of their directory.
+func (o *RunOptions) LintAllPackages(args []string) error {
+	packages, err := lintPackages(args)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, files := range packages {
+		// Lint every package as an independent program.
+		po := *o
+		po.Entries = files
+		po.CompileOnly = true
+		if err := po.Run(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", filepath.Dir(files[0]), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// lintPackages groups the lint targets of args into one file list per
+// directory, in deterministic order:
+//   - `...` patterns walk their root directory recursively;
+//   - plain directories contribute their top-level KCL files, i.e. their
+//     root package only;
+//   - plain files join the list of their parent directory.
+func lintPackages(args []string) ([][]string, error) {
+	filesByDir := map[string][]string{}
+	addFile := func(file string) {
+		file = filepath.Clean(file)
+		dir := filepath.Dir(file)
+		if !slices.Contains(filesByDir[dir], file) {
+			filesByDir[dir] = append(filesByDir[dir], file)
+		}
+	}
+	addDir := func(dir string, recursively bool) error {
+		return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if !recursively && path != dir {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(path, ".k") {
+				addFile(path)
+			}
+			return nil
+		})
+	}
+	for _, arg := range args {
+		if isLintPattern(arg) {
+			if err := addDir(filepath.Dir(arg), true); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if info, err := os.Stat(arg); err == nil && info.IsDir() {
+			if err := addDir(filepath.Clean(arg), false); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		addFile(arg)
+	}
+	if len(filesByDir) == 0 {
+		return nil, fmt.Errorf("no KCL files found in %s", strings.Join(args, " "))
+	}
+	dirs := make([]string, 0, len(filesByDir))
+	for dir := range filesByDir {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	packages := make([][]string, 0, len(dirs))
+	for _, dir := range dirs {
+		files := filesByDir[dir]
+		sort.Strings(files)
+		packages = append(packages, files)
+	}
+	return packages, nil
+}

--- a/pkg/options/lint_test.go
+++ b/pkg/options/lint_test.go
@@ -1,0 +1,106 @@
+// Copyright The KCL Authors. All rights reserved.
+
+package options
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHasLintPattern(t *testing.T) {
+	tests := []struct {
+		args []string
+		want bool
+	}{
+		{args: nil, want: false},
+		{args: []string{"main.k"}, want: false},
+		{args: []string{"pkg/...x", "main.k"}, want: false},
+		{args: []string{"./..."}, want: true},
+		{args: []string{"pkg/..."}, want: true},
+		{args: []string{"..."}, want: true},
+		{args: []string{"main.k", "./..."}, want: true},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, HasLintPattern(tt.args), tt.want, "args: %v", tt.args)
+	}
+}
+
+func TestLintPackages(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    [][]string
+		wantErr bool
+	}{
+		{
+			name: "pattern selects every package recursively",
+			args: []string{"./testdata/lint/..."},
+			want: [][]string{
+				{"testdata/lint/main.k"},
+				{"testdata/lint/nested/sub/warn.k"},
+				{"testdata/lint/pkg_dup/dup.k"},
+			},
+		},
+		{
+			name: "plain directory selects its root package only",
+			args: []string{"./testdata/lint"},
+			want: [][]string{{"testdata/lint/main.k"}},
+		},
+		{
+			name: "plain file joins its directory package",
+			args: []string{"./testdata/lint/pkg_dup/dup.k", "./testdata/lint/..."},
+			want: [][]string{
+				{"testdata/lint/main.k"},
+				{"testdata/lint/nested/sub/warn.k"},
+				{"testdata/lint/pkg_dup/dup.k"},
+			},
+		},
+		{
+			name:    "no KCL files is an error",
+			args:    []string{filepath.Join(t.TempDir(), "...")},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := lintPackages(tt.args)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+
+// TestLintAllPackagesLintsEveryPackageIndependently lints a tree where the
+// schema `S` is declared by two distinct packages: linting every package as
+// an independent program does not collide the duplicate declarations, while
+// linting both files as one program does.
+func TestLintAllPackagesLintsEveryPackageIndependently(t *testing.T) {
+	// Both files in a single program redeclare the schema `S`.
+	merged := NewRunOptions()
+	merged.Entries = []string{"./testdata/lint/main.k", "./testdata/lint/pkg_dup/dup.k"}
+	merged.CompileOnly = true
+	assert.Assert(t, merged.Run() != nil)
+
+	// Lint every package independently instead.
+	o := NewRunOptions()
+	o.NoStyle = true
+	err := o.LintAllPackages([]string{"./testdata/lint/main.k", "./testdata/lint/pkg_dup"})
+	assert.NilError(t, err)
+}
+
+// TestLintAllPackagesReportsFindings ensures lint findings of a package fail
+// the lint and are attributed to the package directory.
+func TestLintAllPackagesReportsFindings(t *testing.T) {
+	o := NewRunOptions()
+	o.NoStyle = true
+	err := o.LintAllPackages([]string{"./testdata/lint/nested/..."})
+	assert.Assert(t, err != nil)
+	assert.ErrorContains(t, err, filepath.Join("testdata", "lint", "nested", "sub"))
+	assert.ErrorContains(t, err, "Module 'math' imported but unused")
+}

--- a/pkg/options/testdata/lint/main.k
+++ b/pkg/options/testdata/lint/main.k
@@ -1,0 +1,2 @@
+schema S:
+    name: str

--- a/pkg/options/testdata/lint/nested/sub/warn.k
+++ b/pkg/options/testdata/lint/nested/sub/warn.k
@@ -1,0 +1,3 @@
+import math
+
+value = 1

--- a/pkg/options/testdata/lint/pkg_dup/dup.k
+++ b/pkg/options/testdata/lint/pkg_dup/dup.k
@@ -1,0 +1,2 @@
+schema S:
+    count: int


### PR DESCRIPTION
## Summary

`kcl lint` now accepts `...` patterns (e.g. `./...` or `pkg/...`) like `go build ./...`: every directory holding KCL files under the pattern root is linted as one package, so symbols of distinct packages never collide and every package of a tree gets linted instead of only the root one (kcl-lang/kcl#1691).

- plain files and directories passed alongside a pattern join the package of their directory; a plain directory still selects its root package only
- every package is linted through the existing compile-only program path, so diagnostics keep their positions and styles, findings still fail the lint with a non-zero exit, and no newer runtime version is required
- errors of each package are prefixed with the package directory
- linting without a pattern is unchanged

```console
$ cd pkg/options/testdata/lint
$ kcl lint ./...
nested/sub:
warning[W1001]: UnusedImportWarning
  --> .../testdata/lint/nested/sub/warn.k:1:1
1 | import math
  | ^ Module 'math' imported but unused
```

The tree declares `schema S` in two distinct packages; `./...` lints both cleanly while `kcl lint main.k pkg_dup/dup.k` (one program) still reports `Unique key error name 'S'` — covered by the added tests.

## Test plan

- [x] `go test ./pkg/options/` — grouping unit tests (pattern/plain dir/plain file/empty), per-package independence (duplicate `schema S` lints clean, merged program fails), findings reported with package attribution
- [x] manual smoke: `kcl lint ./...`, `kcl lint .`, `kcl lint main.k pkg_dup/dup.k`, empty tree error

Fixes kcl-lang/kcl#1691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>